### PR TITLE
Add support for python3 in get_proxy_auth_header method

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -861,7 +861,7 @@ class AWSAuthConnection(object):
         return path
 
     def get_proxy_auth_header(self):
-        auth = encodebytes(self.proxy_user + ':' + self.proxy_pass)
+        auth = encodebytes((self.proxy_user + ':' + self.proxy_pass).encode()).decode()
         return {'Proxy-Authorization': 'Basic %s' % auth}
 
     # For passing proxy information to other connection libraries, e.g. cloudsearch2


### PR DESCRIPTION
We are encoding the string parameters passed to encodebytes and decoding the resulting bytes to be returned from get_proxy_auth_header